### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ Those are the recommended ways of preloading observability instrumentation (in n
 2. Defining an instrumentation hook which preloads instrumentation code at startup
 3. Combination of methods 1 and 2 described above: Defining an instrumentation hook inside an optional instrumentation
    file.
-4. Making use fo the Node Diagnostics Channel, where Node libraries can publish events to
 
 #### 1. Optional instrumentation file
 


### PR DESCRIPTION
I think this is not correct/relevant for this case - as framework author, you do not need to care about diagnostics channel. 

Maybe this is also a tricky aspect because a framework author also may fall into the node library aspect - maybe we should rephrase the categories a bit:

* Meta-Framework Authors - You want to enable users of your framework to add obervability instrumentation to your app in an easy-to-use way.
* Infrastructure Vendors - You want to enable users of your infrastructure to add ob observability instrumentation to any application.
* Library Authors - You want to emit data that observability instrumentation can use.

something along these lines? 🤔 